### PR TITLE
fix: recover from stale DB connections after container restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,11 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./src/backend/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d pedestrian_safety"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   api:
     build:
@@ -21,7 +26,8 @@ services:
     volumes:
       - ./src:/app/src
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
 volumes:
   postgres_data:

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -36,9 +36,21 @@ class _PooledConn:
         return self.conn
 
     def __exit__(self, exc_type, *_):
+        global _pool
         if exc_type:
-            self.conn.rollback()
-        _get_pool().putconn(self.conn)
+            try:
+                self.conn.rollback()
+                _get_pool().putconn(self.conn)
+            except Exception:
+                # Connection is broken (e.g. DB restarted); close it and reset
+                # the pool so the next request gets fresh connections.
+                try:
+                    self.conn.close()
+                except Exception:
+                    pass
+                _pool = None
+        else:
+            _get_pool().putconn(self.conn)
 
 
 # ── CORS ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Root cause of "Error loading data"**: When the DB container restarts during a deploy, the psycopg2 connection pool holds broken connections. The old `_PooledConn.__exit__` attempted a `rollback()` on the dead connection, and if that threw, the connection was never returned to the pool — leaking it. After `minconn=2` requests, the pool was exhausted and every `/api/incidents` call returned 503, triggering the "Error loading data" message in the frontend.
- **Fix**: `__exit__` now catches a failed rollback, closes the dead connection, and sets `_pool = None` so the next request builds a fresh pool against the (now-recovered) DB.
- **Startup race fix**: Added `pg_isready` healthcheck to the `db` service and changed the `api` `depends_on` to `condition: service_healthy`, so the API container never starts before PostgreSQL is actually ready to accept connections.

## Test plan

- [ ] Deploy with `docker compose up -d --build`
- [ ] Verify `/api/health` returns `{"status": "ok"}`
- [ ] Verify `/api/incidents?year=2023` returns a GeoJSON response (or empty features array)
- [ ] Confirm the map loads data without "Error loading data"
- [ ] Simulate DB restart (`docker compose restart db`) and confirm the API self-recovers within a few seconds

https://claude.ai/code/session_01XadzfWRDHZB8jxCJUM5MR1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XadzfWRDHZB8jxCJUM5MR1)_