### PR TITLE
fix: surface real DB error and add fallback DATABASE_URL

### DIFF
--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -16,13 +16,17 @@ app = Flask(__name__, static_folder='../frontend', static_url_path='')
 _pool = None
 
 
+_DEFAULT_DSN = 'postgresql://postgres:postgres@db:5432/pedestrian_safety'
+
+
 def _get_pool():
     global _pool
     if _pool is None:
+        dsn = os.environ.get('DATABASE_URL', _DEFAULT_DSN)
         _pool = psycopg2.pool.ThreadedConnectionPool(
             minconn=2,
             maxconn=10,
-            dsn=os.environ['DATABASE_URL'],
+            dsn=dsn,
             cursor_factory=psycopg2.extras.RealDictCursor,
         )
     return _pool

--- a/src/frontend/js/app.js
+++ b/src/frontend/js/app.js
@@ -903,7 +903,14 @@ async function loadAnimData() {
     for (let y = Math.min(yearFrom, yearTo); y <= Math.max(yearFrom, yearTo); y++) years.push(y);
 
     const responses = await Promise.all(
-      years.map(y => fetch(`/api/incidents?year=${y}`).then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); }))
+      years.map(y => fetch(`/api/incidents?year=${y}`).then(async r => {
+        if (!r.ok) {
+          let detail = '';
+          try { detail = (await r.json()).error || ''; } catch { /* ignore parse errors */ }
+          throw new Error(`HTTP ${r.status}${detail ? ': ' + detail : ''}`);
+        }
+        return r.json();
+      }))
     );
     const allFeatures = responses.flatMap(r => r.features);
     allLoadedFeatures = allFeatures;
@@ -963,9 +970,9 @@ async function loadAnimData() {
       animFrame = requestAnimationFrame(animTick);
     }
   } catch (err) {
-    countEl.textContent = 'Error loading data';
+    countEl.textContent = `Error loading data — ${err.message}`;
     endLoad();
-    console.error(err);
+    console.error('[loadAnimData]', err.message);
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #12 — the error is still showing, meaning the root cause is something different from pool exhaustion. These two changes help diagnose and fix it:

- **`app.py`**: `os.environ['DATABASE_URL']` was raising a bare `KeyError` when `.env` is absent, returning `{"error": "DATABASE_URL"}` — just the key name, not useful. Switched to `os.environ.get()` with a default DSN matching the docker-compose credentials (`postgres:postgres@db:5432/pedestrian_safety`) so the app works even without a `.env` file.
- **`app.js`**: The fetch was discarding the API response body on non-2xx status, so the UI always showed the same generic "Error loading data" regardless of cause. Now the error body is parsed and the actual message is appended in the control panel and logged to the console — e.g. `Error loading data — HTTP 503: could not connect to server`.

## Test plan

- [ ] Deploy and reload the page
- [ ] If the error still shows, it will now include the actual reason (e.g. `connection refused`, `password authentication failed`, `relation "incidents" does not exist`)
- [ ] That detail narrows down whether it's a missing `.env`, wrong credentials, unreachable DB, or missing data

https://claude.ai/code/session_01XadzfWRDHZB8jxCJUM5MR1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XadzfWRDHZB8jxCJUM5MR1)_