### PR TITLE
fix: pin DATABASE_URL to docker db service hostname in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,11 @@ services:
     build:
       context: .
       dockerfile: src/backend/Dockerfile
-    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/pedestrian_safety
+    env_file:
+      - path: .env
+        required: false
     ports:
       - "5001:5000"
     volumes:


### PR DESCRIPTION
## Root cause

The server's `.env` had `DATABASE_URL=postgresql://...@localhost:5432/...`. Inside the `api` container, `localhost` means the container itself — not the `db` service — so every connection attempt hit `127.0.0.1:5432` (nothing listening) and returned the "Connection refused" 503.

## Fix

Set `DATABASE_URL` directly in the `api` service's `environment` block in `docker-compose.yml`. Docker Compose gives `environment` higher precedence than `env_file`, so the correct `db` hostname is always used regardless of what `.env` says.

Also marked `.env` as `required: false` so the container starts even when the file is absent.

## Test plan

- [ ] Merge and let the deploy workflow run
- [ ] Reload `safety.eddielathamjones.com` — incidents should load on the map
- [ ] Optionally verify: `docker compose exec api env | grep DATABASE_URL` should show `@db:5432`

https://claude.ai/code/session_01XadzfWRDHZB8jxCJUM5MR1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XadzfWRDHZB8jxCJUM5MR1)_