### PR TITLE
feat: add 2024 FARS data support

### DIFF
--- a/scripts/check_fars_update.py
+++ b/scripts/check_fars_update.py
@@ -12,7 +12,7 @@ import sys
 import requests
 
 BASE_URL = "https://static.nhtsa.gov/nhtsa/downloads/FARS"
-DB_MAX_YEAR = 2023  # update this when new data is ingested
+DB_MAX_YEAR = 2024  # update this when new data is ingested
 
 
 def year_available(year: int, timeout: int = 10) -> bool:

--- a/scripts/data_download.py
+++ b/scripts/data_download.py
@@ -134,7 +134,7 @@ def download_fars_data(years, base_dir="data/raw"):
 
 if __name__ == "__main__":
     # Years to download
-    years_to_download = range(1975, 2023)  # From 1975 to 2022
+    years_to_download = range(1975, 2025)  # From 1975 to 2024
     
     # Ensure path separators are correct for the operating system
     base_dir = os.path.join("data", "raw")

--- a/src/frontend/js/app.js
+++ b/src/frontend/js/app.js
@@ -2,7 +2,7 @@
 
 // ── Config ────────────────────────────────────────────────────
 const YEAR_MIN = 2001;
-const YEAR_MAX = 2023;
+const YEAR_MAX = 2024;
 const DEFAULT_YEAR_FROM = YEAR_MAX - 4;  // last 5 years
 const DEFAULT_YEAR_TO   = YEAR_MAX;
 


### PR DESCRIPTION
## Summary

- Bumps `YEAR_MAX` in the frontend from 2023 → 2024 so the year picker includes 2024
- Updates `data_download.py` range to include 2024
- Updates `check_fars_update.py` `DB_MAX_YEAR` to 2024

## Loading the data on the server

NHTSA blocks downloads from cloud IPs, so the zip must be fetched and loaded directly on the server. After merging and deploying, SSH in and run:

```bash
cd $DEPLOY_PATH

# 1. Download the zip
mkdir -p data/raw/2024
curl -o data/raw/2024/FARS2024NationalCSV.zip \
  https://static.nhtsa.gov/nhtsa/downloads/FARS/2024/National/FARS2024NationalCSV.zip

# 2. Copy into the running api container
docker compose cp data/raw/2024/FARS2024NationalCSV.zip \
  api:/app/data/raw/2024/FARS2024NationalCSV.zip

# 3. Run the ETL
docker compose exec api python -m src.data_processing.etl \
  --years 2024 --data-dir data/raw
```

## Test plan

- [ ] Merge and deploy
- [ ] Run the commands above on the server
- [ ] Reload the site — year picker should go up to 2024
- [ ] Select 2024 in the "To" year and confirm incidents load

https://claude.ai/code/session_01XadzfWRDHZB8jxCJUM5MR1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XadzfWRDHZB8jxCJUM5MR1)_