### PR TITLE
Update data range title to 2024 and remove stale update badge

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -15,10 +15,7 @@
   <div id="controls">
     <div id="controls-header">
       <h1>Pedestrian Fatalities</h1>
-      <p class="subtitle"><a class="subtitle-link" href="https://www.nhtsa.gov/research-data/fatality-analysis-reporting-system-fars" target="_blank" rel="noopener">FARS · 2001–2023</a></p>
-      <a id="data-update-badge" class="data-update-badge hidden"
-         href="https://www.nhtsa.gov/research-data/fatality-analysis-reporting-system-fars"
-         target="_blank" rel="noopener"></a>
+      <p class="subtitle"><a class="subtitle-link" href="https://www.nhtsa.gov/research-data/fatality-analysis-reporting-system-fars" target="_blank" rel="noopener">FARS · 2001–2024</a></p>
     </div>
 
     <div class="control-group">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Updated subtitle from `FARS · 2001–2023` to `FARS · 2001–2024` to reflect the data now covering through 2024
- Removed the `data-update-badge` element — since the DB is now current through 2024, `update_available` will be false and the badge would never appear anyway

## Test plan

- [ ] Verify subtitle reads "FARS · 2001–2024" in the UI header
- [ ] Confirm no "2024 data available" badge appears

https://claude.ai/code/session_012CaQQX17nJpyT5BX5rvSXx
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012CaQQX17nJpyT5BX5rvSXx)_