### PR TITLE
Add solar context to incident popup and methodology documentation

### DIFF
--- a/src/frontend/css/app.css
+++ b/src/frontend/css/app.css
@@ -476,6 +476,42 @@ body {
 }
 .sv-link:hover { border-color: var(--accent); color: var(--text); }
 
+/* ── Solar methodology note ────────────────────────────────── */
+.solar-section {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.solar-info-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0;
+  line-height: 1.5;
+  opacity: 0.6;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+.solar-info-btn:hover { opacity: 1; }
+
+.solar-methodology {
+  font-size: 10px;
+  color: var(--text-muted);
+  line-height: 1.55;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+}
+
+/* Popup: FARS vs solar disagreement indicator */
+.solar-mismatch {
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 600;
+}
+
 /* ── Sun HUD ───────────────────────────────────────────────── */
 #sun-hud {
   position: absolute;

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -128,7 +128,13 @@
     </div>
 
     <div class="divider"></div>
-    <p id="solar-ref" class="subtitle solar-condition"></p>
+    <div class="solar-section">
+      <p id="solar-ref" class="subtitle solar-condition"></p>
+      <button id="solar-info-btn" class="solar-info-btn" title="About solar methodology">&#9432;</button>
+    </div>
+    <div id="solar-methodology" class="solar-methodology hidden">
+      Solar altitude is computed from incident lat/lng and date using SunCalc — independent of FARS lighting codes. The terminator line and night overlay show the day/night boundary at the selected time. FARS lgt_cond is observer-reported and coarse; SunCalc gives precise altitude but cannot account for streetlights, clouds, or local obstructions. Contradictions between the two are flagged in incident popups.
+    </div>
   </div>
 
   <div id="popup" class="hidden">

--- a/src/frontend/js/app.js
+++ b/src/frontend/js/app.js
@@ -432,11 +432,47 @@ map.on('load', () => {
     const row = (label, val) =>
       `<div class="row"><span class="label">${label}</span><span class="value">${val}</span></div>`;
 
+    // Solar context at actual incident time and location using SunCalc
+    let solarRows = '';
+    if (props.year && props.month && props.day && props.hour != null && props.hour <= 23) {
+      const utcOffset = Math.round(lngLat.lng / 15);
+      const utcH = ((props.hour - utcOffset) % 24 + 24) % 24;
+      const incidentDate = new Date(Date.UTC(
+        props.year, props.month - 1, props.day,
+        Math.floor(utcH), Math.round((utcH % 1) * 60)
+      ));
+      const sunPos = SunCalc.getPosition(incidentDate, lngLat.lat, lngLat.lng);
+      const altDeg = sunPos.altitude * (180 / Math.PI);
+
+      const solarLabel = altDeg > 6   ? 'Daytime'
+                       : altDeg > 0   ? 'Sunrise / Sunset'
+                       : altDeg > -6  ? 'Civil twilight'
+                       : altDeg > -12 ? 'Nautical twilight'
+                       :                'Night';
+      const altSign = altDeg >= 0 ? '+' : '−';
+      const altStr  = `${altSign}${Math.abs(altDeg).toFixed(1)}°`;
+
+      // Flag clear contradictions between FARS observer code and computed solar position
+      const farsCode = props.lgt_cond;
+      let mismatch = '';
+      if (farsCode === 1 && altDeg < -6) {
+        mismatch = ' <span class="solar-mismatch">⚠ FARS: Daylight</span>';
+      } else if ((farsCode === 2 || farsCode === 3 || farsCode === 6) && altDeg > 6) {
+        mismatch = ' <span class="solar-mismatch">⚠ FARS: Dark</span>';
+      }
+
+      solarRows = [
+        row('Sun altitude', altStr),
+        `<div class="row"><span class="label">Solar</span><span class="value">${solarLabel}${mismatch}</span></div>`,
+      ].join('');
+    }
+
     popupContent.innerHTML = [
       row('Date',     date),
       row('Time',     time),
       row('Lighting', LGT[props.lgt_cond]   || 'Unknown'),
       row('Weather',  WEATHER[props.weather] || 'Unknown'),
+      solarRows,
       props.age && props.age < 998 ? row('Age', props.age) : '',
       SEX[props.sex] ? row('Sex', SEX[props.sex]) : '',
       `<button class="sv-link" id="sv-open-btn">Open Street View →</button>`,
@@ -1128,6 +1164,11 @@ document.getElementById('heat-off').addEventListener('click', () => {
   ['road-heat', 'road-heat-glow'].forEach(id => map.setLayoutProperty(id, 'visibility', 'none'));
   document.getElementById('heat-off').classList.add('active');
   document.getElementById('heat-on').classList.remove('active');
+});
+
+// ── Solar methodology toggle ──────────────────────────────────
+document.getElementById('solar-info-btn')?.addEventListener('click', () => {
+  document.getElementById('solar-methodology')?.classList.toggle('hidden');
 });
 
 // ── Visible feature counter ───────────────────────────────────


### PR DESCRIPTION
Closes #9.

## What changed

### Incident popup — solar context
When a user clicks an incident dot, the popup now shows two new rows computed from the incident's actual lat/lng, date, and hour using SunCalc (already loaded on the page):

- **Sun altitude** — the sun's elevation above/below the horizon at that exact moment and location (e.g. `−14.3°`)
- **Solar** — a human-readable condition label: Daytime / Sunrise / Sunset / Civil twilight / Nautical twilight / Night

If the FARS observer-reported `lgt_cond` field clearly contradicts the computed solar position, an inline warning is shown in accent colour:
- FARS says `Daylight` but sun was below −6° → `⚠ FARS: Daylight`
- FARS says `Dark` (codes 2, 3, 6) but sun was above +6° → `⚠ FARS: Dark`

The UTC offset is approximated from the incident longitude (`Math.round(lng / 15)`) — the same approach used elsewhere in the codebase for the solar curve.

### Solar methodology documentation
A small `ⓘ` button now appears next to the solar condition line at the bottom of the controls panel. Clicking it toggles a brief methodology note explaining:
- What SunCalc computes (solar altitude from lat/lng + datetime)
- How the terminator line and night overlay are derived
- Why solar position is used instead of / alongside FARS `lgt_cond`
- The limitation: FARS is observer-reported and coarse; SunCalc is precise but cannot account for streetlights, clouds, or local obstructions

### CSS additions
- `.solar-mismatch` — accent-coloured warning text in the popup
- `.solar-section` / `.solar-info-btn` — flex wrapper and info button for the controls panel solar line
- `.solar-methodology` — collapsible methodology note panel

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYa8AWbLeuh6TVtPH3FM1J)_