### PR TITLE
fix: document annual FARS update workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,30 @@ Downloads all years to `data/raw/` as `FARS{year}NationalCSV.zip`. Decimal lat/l
 
 ---
 
+## Keeping Data Current
+
+NHTSA publishes new FARS data annually, typically August–October for the prior year. There's no automated ingestion yet — check and update manually:
+
+```bash
+# 1. Check whether NHTSA has published a year beyond what's loaded
+python scripts/check_fars_update.py
+# Exits 1 (and prints the new year) if an update is available, 0 if current.
+
+# 2. Download just the new year
+python scripts/data_download.py --years 2025
+
+# 3. Load the new year (the ETL has no dedup/upsert logic — only run it for
+#    years not already in the database, or you'll get duplicate rows)
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/pedestrian_safety \
+  python -m src.data_processing.etl --years 2025 --data-dir data/raw
+
+# 4. Bump DB_MAX_YEAR in scripts/check_fars_update.py to the new year
+```
+
+To automate the check, schedule `scripts/check_fars_update.py` as a yearly cron (e.g. `0 9 1 10 *` — 9am Oct 1) on whatever host runs the deploy; a non-zero exit means new data is available.
+
+---
+
 ## Project Structure
 
 ```

--- a/scripts/data_download.py
+++ b/scripts/data_download.py
@@ -133,13 +133,29 @@ def download_fars_data(years, base_dir="data/raw"):
                     time.sleep(1)
 
 if __name__ == "__main__":
-    # Years to download
-    years_to_download = range(1975, 2025)  # From 1975 to 2024
-    
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Download FARS data zips from NHTSA")
+    parser.add_argument(
+        "--years", type=str, default=None,
+        help="Year or range to download, e.g. '2024' or '2020-2024'. "
+             "Defaults to the full 1975-2024 archive."
+    )
+    args = parser.parse_args()
+
+    if args.years:
+        if "-" in args.years:
+            start, end = (int(y) for y in args.years.split("-", 1))
+            years_to_download = range(start, end + 1)
+        else:
+            years_to_download = [int(args.years)]
+    else:
+        years_to_download = range(1975, 2025)  # From 1975 to 2024
+
     # Ensure path separators are correct for the operating system
     base_dir = os.path.join("data", "raw")
-    
+
     # Download data
     download_fars_data(years_to_download, base_dir)
-    
+
     print("\nDownload process completed.")


### PR DESCRIPTION
Fixes #10 (partially — see below).

Adds the "Keeping Data Current" section to README documenting the check → download → ETL → bump-`DB_MAX_YEAR` loop, and adds a `--years` flag to `scripts/data_download.py` so a single new year (or range) can be downloaded without re-fetching the entire 1975–2024 archive.

**What's not in this PR:** the actual cron installation on eddienet. This session has no SSH/deploy access to eddienet, so the cron scheduling piece from the issue (`0 9 1 10 *` running `check_fars_update.py`) needs to be wired up manually on the server — commented on the issue with the exact line to add. Also flagged: `src/data_processing/etl.py` has no dedup/upsert logic, so it is *not* safe to re-run against a year already loaded (contrary to what the issue assumed) — documented that caveat in the README rather than fixing it, since deduping would need a schema change (unique constraint + `ON CONFLICT`) beyond this issue's scope.

- [x] No test suite in this repo to run
- [x] Verified `scripts/data_download.py --years 2024` / `--years 2020-2024` parse correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5yve8ALHx4ccYhbRwnoBr)_